### PR TITLE
Set parent element for cookie-consent

### DIFF
--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -36,6 +36,8 @@
     {{> nav}}
     {{> body}}
 
+    <div id="consent"></div>
+
     {{#if build.production}}
     {{> google_analytics}}
     {{/if}}

--- a/src/partials/deferred_js.html
+++ b/src/partials/deferred_js.html
@@ -37,6 +37,7 @@
         var element = window.cookieconsent;
         if (element) {
             element.initialise({
+                "container": document.getElementById("consent"),
                 "palette": {
                     "popup": {
                         "background": "#333"


### PR DESCRIPTION
Google search results currently appear like this, probably because the cookie-consent is being injected at the top of the body section:

> Quartic - Big data for big maintenance
https://www.quartic.io/
This website uses cookies to ensure you get the best experience on our website. Learn more. Got it! Big data for big maintenance. Road · Rail · Utilities.
Block quartic.io

So inject it at the bottom instead.